### PR TITLE
Feature/config provider

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -7,7 +7,7 @@
         <processorPath useClasspath="false">
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.28/a2ff5da8bcd8b1b26f36b806ced63213362c6dcc/lombok-1.18.28.jar" />
         </processorPath>
-        <module name="de.jonafaust.jda-boot.main" />
+        <module name="jda-boot.main" />
       </profile>
     </annotationProcessing>
     <bytecodeTargetLevel target="17" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,9 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="corretto-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="temurin-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
   <component name="ProjectType">

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,7 +2,6 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/de.jonafaust.jda-boot.main.iml" filepath="$PROJECT_DIR$/.idea/modules/de.jonafaust.jda-boot.main.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/jda-boot.main.iml" filepath="$PROJECT_DIR$/.idea/modules/jda-boot.main.iml" />
     </modules>
   </component>

--- a/.idea/modules/jda-boot.main.iml
+++ b/.idea/modules/jda-boot.main.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module version="4">
-  <component name="NewModuleRootManager">
+  <component name="AdditionalModuleElements">
     <content url="file://$MODULE_DIR$/../../build/generated/sources/annotationProcessor/java/main">
       <sourceFolder url="file://$MODULE_DIR$/../../build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
     </content>

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'maven-publish'
 }
 
-group 'de.jonafaust'
+group 'de.swiftbyte'
 version 'alpha3.4'
 
 repositories {
@@ -34,4 +34,16 @@ dependencies {
 
 test {
     useJUnitPlatform()
+}
+
+
+publishing {
+    repositories {
+        mavenLocal()
+    }
+    publications {
+        maven(MavenPublication) {
+            from(components.java)
+        }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'de.swiftbyte'
-version 'alpha3.4'
+version 'alpha3.5'
 
 repositories {
     mavenCentral()

--- a/src/main/java/de/swiftbyte/jdaboot/configuration/Config.java
+++ b/src/main/java/de/swiftbyte/jdaboot/configuration/Config.java
@@ -1,114 +1,21 @@
 package de.swiftbyte.jdaboot.configuration;
 
-import lombok.extern.slf4j.Slf4j;
-
-import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 
-@Slf4j
-public class Config {
+public interface Config {
+    String getString(String key);
 
-    private static Config instance;
-    private static HashMap<String, Object> configDefaultValues = new HashMap<>();
-    private static File file;
-    private static Properties properties;
+    int getInt(String key);
 
+    boolean getBoolean(String key);
 
+    Config set(String key, Object value);
 
-    public static final String CONFIG_FILE_NAME = "config.properties";
+    void save();
 
-    protected Config() throws IOException {
-        properties = new Properties();
-        file = new File(CONFIG_FILE_NAME);
-        defaultValues();
-        checkFile();
-        properties.load(new FileReader(file));
-    }
+    Config reload();
 
-    private Map<String, Object> defaultValues() {
-        configDefaultValues.put("discord.token", "BOT TOKEN");
-        return configDefaultValues;
-    }
+    void addDefaultValue(String key, Object value);
 
-    public String getString(String key) {
-        String value = properties.getProperty(key);
-        if (value == null) configSyntaxError();
-        return value;
-    }
-
-    public int getInt(String key) {
-        String value = properties.getProperty(key);
-        if (value == null) configSyntaxError();
-        return Integer.parseInt(value);
-    }
-
-    public boolean getBoolean(String key) {
-        String value = properties.getProperty(key);
-        if (value == null) configSyntaxError();
-        return Boolean.parseBoolean(value);
-    }
-
-    public Config set(String key, Object value) {
-        properties.setProperty(key, value.toString());
-        return this;
-    }
-
-    public void save() {
-        try {
-            properties.store(new FileWriter(file), "JDABoot Configuration");
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public Config reload() {
-        try {
-            properties.load(new FileReader(file));
-            return this;
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public void addDefaultValue(String key, Object value) {
-        if (!properties.containsKey(key)) {
-            properties.setProperty(key, value.toString());
-        }
-    }
-
-    public void addDefaultValues(Map<String, Object> values) {
-        values.forEach(this::addDefaultValue);
-    }
-
-    private void checkFile() throws IOException {
-        if(!file.exists()) {
-            file.createNewFile();
-            addDefaultValues(configDefaultValues);
-            save();
-            log.info("Created new config file, the system will now exit. Please fill in the values and restart the bot.");
-            System.exit(0);
-        }
-    }
-
-    private void configSyntaxError() {
-        log.error("Config syntax error, please check the config file. If you have no idea what to do, delete the config file and restart the bot.\n Then the bot will create a new config file with the default values.");
-        System.exit(0);
-    }
-
-    public static Config getInstance() {
-        if (instance == null) {
-            try {
-                instance = new Config();
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
-        return instance;
-    }
-
+    void addDefaultValues(Map<String, Object> values);
 }

--- a/src/main/java/de/swiftbyte/jdaboot/configuration/PropertiesConfig.java
+++ b/src/main/java/de/swiftbyte/jdaboot/configuration/PropertiesConfig.java
@@ -1,0 +1,122 @@
+package de.swiftbyte.jdaboot.configuration;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+@Slf4j
+public class PropertiesConfig implements Config {
+
+    private static Config instance;
+    private static HashMap<String, Object> configDefaultValues = new HashMap<>();
+    private static File file;
+    private static Properties properties;
+
+
+
+    public static final String CONFIG_FILE_NAME = "config.properties";
+
+    protected PropertiesConfig(File configFile) throws IOException {
+        properties = new Properties();
+        file = configFile;
+        defaultValues();
+        checkFile();
+        properties.load(new FileReader(file));
+    }
+
+    private Map<String, Object> defaultValues() {
+        configDefaultValues.put("discord.token", "BOT TOKEN");
+        return configDefaultValues;
+    }
+
+    public String getString(String key) {
+        String value = properties.getProperty(key);
+        if (value == null) configSyntaxError();
+        return value;
+    }
+
+    public int getInt(String key) {
+        String value = properties.getProperty(key);
+        if (value == null) configSyntaxError();
+        return Integer.parseInt(value);
+    }
+
+    public boolean getBoolean(String key) {
+        String value = properties.getProperty(key);
+        if (value == null) configSyntaxError();
+        return Boolean.parseBoolean(value);
+    }
+
+    public Config set(String key, Object value) {
+        properties.setProperty(key, value.toString());
+        return this;
+    }
+
+    public void save() {
+        try {
+            properties.store(new FileWriter(file), "JDABoot Configuration");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public Config reload() {
+        try {
+            properties.load(new FileReader(file));
+            return this;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void addDefaultValue(String key, Object value) {
+        if (!properties.containsKey(key)) {
+            properties.setProperty(key, value.toString());
+        }
+    }
+
+    public void addDefaultValues(Map<String, Object> values) {
+        values.forEach(this::addDefaultValue);
+    }
+
+    private void checkFile() throws IOException {
+        if(!file.exists()) {
+            file.createNewFile();
+            addDefaultValues(configDefaultValues);
+            save();
+            log.info("Created new config file, the system will now exit. Please fill in the values and restart the bot.");
+            System.exit(0);
+        }
+    }
+
+    private void configSyntaxError() {
+        log.error("Config syntax error, please check the config file. If you have no idea what to do, delete the config file and restart the bot.\n Then the bot will create a new config file with the default values.");
+        System.exit(0);
+    }
+
+    public static Config getInstance() {
+        if (instance == null) {
+            try {
+                instance = new PropertiesConfig(new File(CONFIG_FILE_NAME));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return instance;
+    }
+
+    public static Config getInstance(File configFile) {
+        if (instance == null) {
+            try {
+                instance = new PropertiesConfig(configFile);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return instance;
+    }
+
+}


### PR DESCRIPTION
With the ConfigProvider the user of JDABoot can specify some code on his own and it is possible to not use the default config.properties provided.
The Settings were implemented to future-proof JDABoot and prevent the constructor and run() methods from getting messy because of too many parameters that are passed to them.

**I strongly recommend to remove the newly deprecated run() method as soon as possible.**